### PR TITLE
Feat. Make get_all_open_time more faster

### DIFF
--- a/iqoptionapi/stable_api.py
+++ b/iqoptionapi/stable_api.py
@@ -336,9 +336,9 @@ class IQ_Option:
         digital = threading.Thread(target=self.__get_digital_open)
         other = threading.Thread(target=self.__get_other_open)
 
-        binary.run(), digital.run(), other.run()
+        binary.start(), digital.start(), other.start()
 
-        # binary.join(), digital.join(), other.join()
+        binary.join(), digital.join(), other.join()
         return self.OPEN_TIME
 
     # --------for binary option detail


### PR DESCRIPTION
## Fazer o método get_all_open_time mais performático.

Atualmente o uso do método é dado por três chamadas independentes umas das outras que no final são unidas para formar a resposta dada ao usuário.
O processo de busca é "pesado para a internet" como diz a própria documentação, porém boa parte do delay causado no código não se da apenas a requisição feita.

Print do tempo que demora atualmente para funcionar todo o processo.
![image](https://user-images.githubusercontent.com/43057423/150622859-e65aa350-b752-44b7-98e3-4686ef8eebea.png)

Tempo atingido -> 4.41 segundos (essa é a média que obtive)

## Resolução: multi-threading

Como todas as três partes para cada um dos tipos são diferentes entre si, os códigos foram isolados em "métodos privados", para o uso do threading.
-> Binário: https://github.com/Lu-Yi-Hsun/iqoptionapi/blob/3cdfefdf6cc00bc3dfef03a2175e2f37e2ce6cf1/iqoptionapi/stable_api.py#L254-L258
-> Digital:  https://github.com/Lu-Yi-Hsun/iqoptionapi/blob/3cdfefdf6cc00bc3dfef03a2175e2f37e2ce6cf1/iqoptionapi/stable_api.py#L270-L272
Make it easy to code review
-> Forex, crypto e etc: https://github.com/Lu-Yi-Hsun/iqoptionapi/blob/3cdfefdf6cc00bc3dfef03a2175e2f37e2ce6cf1/iqoptionapi/stable_api.py#L282-L284

Resultado final: 
[    `def __get_binary_open(self):`](https://github.com/lusqua/iqoptionapi/blob/25f442bd10d7251139eb6fbf1abe2e0d5c32ddd8/iqoptionapi/stable_api.py#L286)
[   ` def __get_digital_open(self):`](https://github.com/lusqua/iqoptionapi/blob/25f442bd10d7251139eb6fbf1abe2e0d5c32ddd8/iqoptionapi/stable_api.py#L304)
[    `def __get_other_open(self):`](https://github.com/lusqua/iqoptionapi/blob/25f442bd10d7251139eb6fbf1abe2e0d5c32ddd8/iqoptionapi/stable_api.py#L317)


```
        binary = threading.Thread(target=self.__get_binary_open)
        digital = threading.Thread(target=self.__get_digital_open)
        other = threading.Thread(target=self.__get_other_open)
```
https://github.com/lusqua/iqoptionapi/blob/25f442bd10d7251139eb6fbf1abe2e0d5c32ddd8/iqoptionapi/stable_api.py#L335
## Resultado obtido após testes.

![image](https://user-images.githubusercontent.com/43057423/150623075-7ac7a0f2-9771-480e-9b59-48dfa51a0539.png)

Resultado chega próximo de 25% a menos de tempo do anterior, fazendo uma diferença perceptível (1 sec a menos) .

## Como testar.

Código que eu utilizei para testes.

```
from iqoptionapi.stable_api import IQ_Option
from time import time

api = IQ_Option("", "")
api.connect()

start = time()

print(api.get_all_open_time())

end = time()

print(f"Tempo total {round(end-start,2)} segundos")
```
