### PR TITLE
Forcing connect on startup to create self.api

### DIFF
--- a/iqoptionapi/stable_api.py
+++ b/iqoptionapi/stable_api.py
@@ -46,7 +46,10 @@ class IQ_Option:
         self.SESSION_COOKIE = {}
         #
         # --start
-        # self.connect()
+        ## self.api is only created on this function and it's needed
+        ## for every function of this class, so force starting it on the
+        ## constructor
+        self.connect()
         # this auto function delay too long
 
     # --------------------------------------------------------------------------


### PR DESCRIPTION
## Issue Description

Most **IQ_Option** class methods won't work before `connect()` is called because until there the instance doesn't have the **api** attribute.

## Proposed Change

- Forcing `self.connect()` in the constructor ensures **self.api** exists.

## Tested code evidence

## How to test code

```
from iqoptionapi.stable_api import IQ_Option
iq = IQ_Option(email, password)
iq.change_balance('TOURNAMENT') # this won't raise an exception even if iq.connect() wasn't properly called
```
