### PR TITLE
Atualização 7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,7 @@
-## AJUDE A MANTER O PROJETO ATIVO
-EN: HELP KEEPING THIS PROJECT ACTIVE <br>
-
-Para manter o projeto continuamente atualizado contribua com uma doação, com alguma correção ou melhoria.
-
-As doações serão usadas para adicionar novas features citadas abaixo.
-
-https://streamelements.com/iqoptionapi/tip
-<br><br>
-## Español - AYUDA A MANTENER ESTE PROYECTO ACTIVO 
-Para mantener el proyecto continuamente actualizado, contribuye con una donación, con cualquier corrección o mejora.
-
-Las donaciones se utilizarán para agregar nuevas funciones que se mencionan a continuación.
-
-EN: To keep the project continuously updated you can contribute with a donation or with some correction or improvement.
-
-https://streamelements.com/iqoptionapi/tip
-<br><br>
-
-## HELP KEEPING THIS PROJECT ACTIVE
-
-To keep project continuously updated, contribute with a donation, with any correction or improvement.
-
-Donations will be used to add new features mentioned below.
-
-https://streamelements.com/iqoptionapi/tip
-<br><br>
+Intale no python 
+```bash
+pip install git+https://github.com/username/nome-do-repositorio.git
+```
 
 ## PLANEJAMENTO DE NOVAS FEATURES 
 EN: NEW FEATURES PLANNING<br>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
-Instale no python 
-```bash
-pip install git+https://github.com/wujileee/iqoptionapi.git
-```
-
 <div align="center">
 	<h2> Idiomas | Languages </h2>
 	<a href="https://iqoptionapi.github.io/iqoptionapi/pt/">

--- a/README.md
+++ b/README.md
@@ -1,53 +1,7 @@
-Intale no python 
+Instale no python 
 ```bash
-pip install git+https://github.com/username/nome-do-repositorio.git
+pip install git+https://github.com/wujileee/iqoptionapi.git
 ```
-
-## PLANEJAMENTO DE NOVAS FEATURES 
-EN: NEW FEATURES PLANNING<br>
-ES: PLANIFICACIÓN DE NUEVAS CARACTERÍSTICAS
-
-
-- CALENDARIO ECONOMICO / ECONOMIC CALENDAR (UNDER DEVELOPMENT)
-<br><br>
-Descrição: 
-Pega o calendario econimico da iqoption.
-Essa feature vai possibilitar que vocês possar evitar fazer operações quando estiver muito arriscado.
-<br/><br/>
-
-![ECONOMIC CALENDAR](image/econimic_calendar.png)
-<br/>
-
-- FEED DE NOTICIAS/ NEWS FEED 
-<br><br>
-Descrição: 
-Noticias sobre o mercado 
-![NEWS FEED](image/news_feed.png)
-<br/><br/>
-
-## IQOPTION API SUPPORTED BY COMMUNITY
-
-This api is intended to be an open source project to communicate with iqOption site.
-this is a no official repository, it means it is maintained by community
-
-Esta API é destinada a ser um projeto de código aberto para se comunicar com o site da iqOption.
-este é um repositório não oficial, significa que é mantido pela comunidade
-
-Esta API está destinada a ser un proyecto de código abierto para comunicarse con el sitio de IqIoption.
-este es un repositorio no oficial, significa que es mantenido por la comunidad
-
-
-### IMPORTANT NOTE / NOTA IMPORTANTE 
-
-Due to the large amount of scammers that have appeared in the market, it is recommended that you DO NOT enter your password into an unknown exe or robot site that operates on iqoption because many of those have stolen people's passwords so be careful. It's best if you develop your robot or hire someone you trust.
-
-Devido a grande quantidade de golpistas que tem aparecido no mercado, recomenda-se que você NÃO inserir sua senha em exe ou sites de robo desconhecidos que opera na iqoption porque muitos desses tem roubado as senhas das pessoas então tomem cuidado. O melhor é você desenvolver seu robo ou contratar alguem de confiança. 
-
-### Canal no youtube explicando com trabalhar com a api
-
-Kodandao com Faria 
-
-https://www.youtube.com/channel/UCetDOTbLD_gCy0aI4aQwMsg
 
 <div align="center">
 	<h2> Idiomas | Languages </h2>

--- a/iqoptionapi/expiration.py
+++ b/iqoptionapi/expiration.py
@@ -1,6 +1,7 @@
 # python
+import math
+from datetime import datetime as dt, timedelta
 import time
-from datetime import datetime, timedelta
 
 # https://docs.python.org/3/library/datetime.html
 # If optional argument tz is None or not specified, the timestamp is converted to the platform's local date and time, and the returned datetime object is naive.
@@ -13,68 +14,94 @@ def date_to_timestamp(dt):
 
 
 def get_expiration_time(timestamp, duration):
-    #
-    now_date = datetime.fromtimestamp(timestamp)
-    exp_date = now_date.replace(second=0, microsecond=0)
-    if (int(date_to_timestamp(exp_date+timedelta(minutes=1)))-timestamp) > 30:
-        exp_date = exp_date+timedelta(minutes=1)
+    """
+    Calcula o tempo de expiração para ordens na IQ Option.
 
+    Parâmetros:
+    - timestamp: int, timestamp Unix do servidor (hora atual)
+    - duration: int, duração em minutos (1 a 180 minutos)
+
+    Retorna:
+    - tuple: (int, int) - timestamp Unix de expiração e índice (idx)
+    """
+    current_time = dt.fromtimestamp(timestamp)
+
+    if duration <= 5:
+        # Lógica para durações de 1 a 5 minutos (turbo)
+        minutes_to_add = duration if current_time.second < 30 else duration + 1
+        expiration_dt = current_time + timedelta(minutes=minutes_to_add)
+        expiration_dt = expiration_dt.replace(second=0, microsecond=0)
+        idx = duration - 1  # 0 a 4 para turbo
     else:
-        exp_date = exp_date+timedelta(minutes=2)
-    exp = []
-    for _ in range(5):
-        exp.append(date_to_timestamp(exp_date))
-        exp_date = exp_date+timedelta(minutes=1)
+        # Lógica para durações maiores que 5 minutos (binary)
+        # Calcula o tempo de expiração desejado
+        desired_expiration = current_time + timedelta(minutes=duration)
+        minute = desired_expiration.minute
 
-    idx = 50
-    index = 0
-    now_date = datetime.fromtimestamp(timestamp)
-    exp_date = now_date.replace(second=0, microsecond=0)
-    while index < idx:
-        if int(exp_date.strftime("%M")) % 15 == 0 and (int(date_to_timestamp(exp_date))-int(timestamp)) > 60*5:
-            exp.append(date_to_timestamp(exp_date))
-            index = index+1
-        exp_date = exp_date+timedelta(minutes=1)
+        # Múltiplo de 15 anterior
+        prev_multiple = (minute // 15) * 15
+        prev_time = desired_expiration.replace(minute=prev_multiple, second=0, microsecond=0)
 
-    remaning = []
+        # Múltiplo de 15 posterior
+        next_multiple = math.ceil((minute + 1) / 15) * 15
+        if next_multiple >= 60:
+            next_time = desired_expiration.replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
+        else:
+            next_time = desired_expiration.replace(minute=next_multiple, second=0, microsecond=0)
 
-    for t in exp:
-        remaning.append(int(t)-int(time.time()))
+        # Escolhe o mais próximo, garantindo que seja no futuro
+        if prev_time < current_time:
+            expiration_dt = next_time
+        else:
+            if abs((prev_time - desired_expiration).total_seconds()) <= abs((next_time - desired_expiration).total_seconds()):
+                expiration_dt = prev_time
+            else:
+                expiration_dt = next_time
+        idx = 5  # Para binary
 
-    close = [abs(x-60*duration) for x in remaning]
-
-    return int(exp[close.index(min(close))]), int(close.index(min(close)))
+    exp = int(date_to_timestamp(expiration_dt))
+    return exp, idx
 
 
 def get_remaning_time(timestamp):
-    now_date = datetime.fromtimestamp(timestamp)
-    exp_date = now_date.replace(second=0, microsecond=0)
-    if (int(date_to_timestamp(exp_date+timedelta(minutes=1)))-timestamp) > 30:
-        exp_date = exp_date+timedelta(minutes=1)
+    """
+    Calcula os tempos restantes para expirações de curto e longo prazo.
 
+    Parâmetros:
+    - timestamp: int, timestamp Unix do servidor (hora atual)
+
+    Retorna:
+    - list: Lista de tuplas (duração_em_minutos, tempo_restante_em_segundos)
+    """
+    # Converte o timestamp para datetime e zera segundos/microssegundos
+    current_time = dt.fromtimestamp(timestamp)
+    exp_date = current_time.replace(second=0, microsecond=0)
+
+    # Ajuste inicial para expirações de curto prazo
+    seconds_to_next_minute = int(date_to_timestamp(exp_date + timedelta(minutes=1))) - timestamp
+    if seconds_to_next_minute > 30:
+        exp_date += timedelta(minutes=1)
     else:
-        exp_date = exp_date+timedelta(minutes=2)
-    exp = []
-    for _ in range(5):
-        exp.append(date_to_timestamp(exp_date))
-        exp_date = exp_date+timedelta(minutes=1)
-    idx = 11
+        exp_date += timedelta(minutes=2)
+
+    # Gera expirações de curto prazo (1 a 5 minutos)
+    short_term_exps = []
+    for i in range(5):
+        exp_time = int(date_to_timestamp(exp_date))
+        short_term_exps.append((i + 1, exp_time - timestamp))
+        exp_date += timedelta(minutes=1)
+
+    # Gera expirações de longo prazo (múltiplos de 15 minutos)
+    long_term_exps = []
+    exp_date = current_time.replace(second=0, microsecond=0)
     index = 0
-    now_date = datetime.fromtimestamp(timestamp)
-    exp_date = now_date.replace(second=0, microsecond=0)
-    while index < idx:
-        if int(exp_date.strftime("%M")) % 15 == 0 and (int(date_to_timestamp(exp_date))-int(timestamp)) > 60*5:
-            exp.append(date_to_timestamp(exp_date))
-            index = index+1
-        exp_date = exp_date+timedelta(minutes=1)
+    while index < 11:
+        exp_time = int(date_to_timestamp(exp_date))
+        if exp_date.minute % 15 == 0 and (exp_time - timestamp) > 300:  # 5 minutos
+            long_term_exps.append((15 * (index + 1), exp_time - timestamp))
+            index += 1
+        exp_date += timedelta(minutes=1)
 
-    remaning = []
+    # Combina as expirações de curto e longo prazo
+    return short_term_exps + long_term_exps
 
-    for idx, t in enumerate(exp):
-        if idx >= 5:
-            dr = 15*(idx-4)
-        else:
-            dr = idx+1
-        remaning.append((dr, int(t)-int(time.time())))
-
-    return remaning

--- a/iqoptionapi/stable_api.py
+++ b/iqoptionapi/stable_api.py
@@ -1591,7 +1591,7 @@ class IQ_Option:
 
         self.api.unsubscribe_digital_price_splitter(asset_id)
 
-        return self.api.digital_payout if self.api.digital_payout else 0
+        return self.api.digital_payout if self.api.digital_payout else 75
 
     def logout(self):
         self.api.logout()

--- a/iqoptionapi/stable_api.py
+++ b/iqoptionapi/stable_api.py
@@ -943,7 +943,6 @@ class IQ_Option:
             except:
                 pass
             try:
-                print(self.api.buy_multi_option[req_id]["id"])
                 id = self.api.buy_multi_option[req_id]["id"]
             except:
                 pass

--- a/iqoptionapi/version_control.py
+++ b/iqoptionapi/version_control.py
@@ -1,1 +1,1 @@
-api_version = "7.1.2"
+api_version = "7.1.3"

--- a/iqoptionapi/version_control.py
+++ b/iqoptionapi/version_control.py
@@ -1,1 +1,1 @@
-api_version = "7.1.1"
+api_version = "7.1.2"

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     name="iqoptionapi",
     version=api_version,
     packages=find_packages(),
-    install_requires=["pylint", "requests", "websocket-client==0.56"],
+    install_requires=["pylint", "requests", "websocket-client==0.56", "openpyxl"],
     include_package_data=True,
     description="Best IQ Option API for python",
     long_description="Best IQ Option API for python",

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 """The python wrapper for IQ Option API package setup."""
-from setuptools import (setup, find_packages)
+from setuptools import setup, find_packages
 from iqoptionapi.version_control import api_version
 
 setup(
@@ -12,5 +12,6 @@ setup(
     long_description="Best IQ Option API for python",
     url="https://github.com/wujileee/iqoptionapi.git",
     author="Wuji Lee",
+    author_email='wujiofc@gmail.com',
     zip_safe=False
 )

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     include_package_data=True,
     description="Best IQ Option API for python",
     long_description="Best IQ Option API for python",
-    url="https://github.com/iqoptionapi/iqoptionapi",
-    author="Rafael Faria",
+    url="https://github.com/wujileee/iqoptionapi.git",
+    author="Wuji Lee",
     zip_safe=False
 )


### PR DESCRIPTION
1 - Todas os pares atuais atualizados, junto o seu ID.

- Chame a função get_all_open_time() para retornar todos os ativos e atualizar todas as IDs constantes dos ativos.

- Chame get_all_open_time('digital') para retornar apenas os ativos digitais e atualizar apenas as IDs constantes dos ativos digitais (para economizar CPU e memória).

- Chame get_all_open_time('binary') para retornar apenas os ativos turbo (expirações de 1 a 5 minutos) e binários (expiração de 15 minutos ou mais) e atualizar apenas as IDs constantes dos ativos turbo e binários (para economizar CPU e memória).

2 - check_win_v4 para ordens binárias mais rápido

```
status, order_id = buy(2, ativo, 'put', 3)
if status:
    while True:
        check, order_profit = check_win_v4(order_id)
        if check:
            break
```

3 - Algumas melhorias adicionais

4 - Ordem de compra binary mais rápida e correção e otimização dos cálculos de tempo de expiração na API

- Corrigido o cálculo incorreto de expirações para turbo e binary sem ser o digital. Anteriormente, durações de 1, 2 e 3 minutos eram mapeadas para 1 minuto, 4 minutos para 2 minutos e 5 minutos para 3 minutos ao chamar a ordem de compra pra binary. Agora, calcula corretamente as expirações 1, 2, 3, 4, 5 e 15+ minutos até 3 horas para pares comuns (se não fechar antes) e até 45 minutos para pares OTC (dependendo do par).

- Adicionado suporte para expirações mais longas (até 3 horas) ao encontrar o múltiplo de 15 minutos mais próximo, garantindo conformidade com as regras de opções binárias da IQ Option.

- Coloque qualquer minutagem que quiser nas expirações até 3 horas (dependendo do tipo, do par e do horário, sempre em minutos, ex: 2 horas = 120)

- Exemplo expiração 1:30h
`buy(2, ativo, 'put', 90)  `

- Essas mudanças garantem um manuseio preciso das expirações e aumentam a confiabilidade da API para a colocação de ordens binárias.

